### PR TITLE
Fix file iteration and snap scroll observer

### DIFF
--- a/app/lib/hooks/useSnapScroll.ts
+++ b/app/lib/hooks/useSnapScroll.ts
@@ -20,6 +20,7 @@ export function useSnapScroll() {
       });
 
       observer.observe(node);
+      observerRef.current = observer;
     } else {
       observerRef.current?.disconnect();
       observerRef.current = undefined;

--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -138,7 +138,7 @@ export class FilesStore {
         case 'remove_dir': {
           this.files.setKey(sanitizedPath, undefined);
 
-          for (const [direntPath] of Object.entries(this.files)) {
+          for (const [direntPath] of Object.entries(this.files.get())) {
             if (direntPath.startsWith(sanitizedPath)) {
               this.files.setKey(direntPath, undefined);
             }


### PR DESCRIPTION
## Summary
- fix removing nested entries in `FilesStore`
- ensure `useSnapScroll` cleans up ResizeObserver correctly

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.4.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_688869654e848324a36d93965ea46f0e